### PR TITLE
RDK-48644: Remove region specific patch.

### DIFF
--- a/subttxrend-ttml/CMakeLists.txt
+++ b/subttxrend-ttml/CMakeLists.txt
@@ -119,6 +119,7 @@ set_property(TARGET ${LIBRARY_NAME} PROPERTY SOVERSION 0)
 set_property(TARGET ${LIBRARY_NAME} PROPERTY PUBLIC_HEADER ${SUBTTXREND_TTML_PUBLIC_HEADERS})
 target_link_libraries(${LIBRARY_NAME} ${LIBSUBTTXRENDCOMMON_LIBRARIES})
 target_link_libraries(${LIBRARY_NAME} ${LIBXML2_LIBRARIES})
+target_link_libraries(${LIBRARY_NAME} jsoncpp)
 
 #
 # Install rules

--- a/subttxrend-ttml/src/Parser/StyleSet.cpp
+++ b/subttxrend-ttml/src/Parser/StyleSet.cpp
@@ -264,7 +264,7 @@ bool operator==(const StyleSet& lhs,
             && (lhs.m_lineHeight == rhs.m_lineHeight) && (lhs.m_textOutline == rhs.m_textOutline);
 }
 
-std::string parseRegionInfo()
+std::string StyleSet::parseRegionInfo()
 {
     std::string key = "country";
     std::string region = "us";

--- a/subttxrend-ttml/src/Parser/StyleSet.hpp
+++ b/subttxrend-ttml/src/Parser/StyleSet.hpp
@@ -72,6 +72,7 @@ public:
 private:
     void parseAttribute(const std::string& name,
                         const std::string& value);
+    std::string parseRegionInfo();
 
     gfx::ColorArgb m_color{gfx::ColorArgb::WHITE};
     gfx::ColorArgb m_backgroundColor{gfx::ColorArgb::TRANSPARENT};


### PR DESCRIPTION
Reason for change: Parse region info from config and apply patch at runtime. Test Procedure: Check for CC appearance.
Risks: Low
Signed-off-by:Anaswara KookkalAnaswara_Kookkal@comcast.com