### PR TITLE
RDK-48644: Remove region specific patch.

### DIFF
--- a/subttxrend-app/CMakeLists.txt
+++ b/subttxrend-app/CMakeLists.txt
@@ -141,6 +141,7 @@ target_link_libraries(${APP_NAME} ${LIBSUBTTXRENDTTML_LIBRARIES})
 target_link_libraries(${APP_NAME} ${LIBSUBTTXRENDWEBVTT_LIBRARIES})
 target_link_libraries(${APP_NAME} pthread)
 target_link_libraries(${APP_NAME} boost_system)
+target_link_libraries(${APP_NAME} jsoncpp)
 
 #
 # Install rules

--- a/subttxrend-app/src/Application.cpp
+++ b/subttxrend-app/src/Application.cpp
@@ -62,7 +62,9 @@ void Application::runAsync()
 
     m_logger.osinfo(__LOGGER_FUNC__, " - window created ", m_gfxWindow.get(), ", initializing controller");
 
-    m_controller = std::make_unique<Controller>(m_configuration, m_gfxEngine, m_gfxWindow);
+    m_region = m_configuration.getRegionInfo();
+
+    m_controller = std::make_unique<Controller>(m_configuration, m_gfxEngine, m_gfxWindow, m_region);
 
     auto socketPath = m_configuration.getMainContextSocketPath();
     m_logger.osinfo( __LOGGER_FUNC__, " - Creating unix socket source with path='", socketPath, "'.");

--- a/subttxrend-app/src/Application.hpp
+++ b/subttxrend-app/src/Application.hpp
@@ -69,6 +69,8 @@ private:
     /** Application window. */
     gfx::WindowPtr m_gfxWindow;
 
+    std::string m_region;
+
     /** Subtitle and teletext control object. */
     ControllerPtr m_controller;
     common::Logger m_logger;

--- a/subttxrend-app/src/Configuration.cpp
+++ b/subttxrend-app/src/Configuration.cpp
@@ -25,6 +25,11 @@
 #include <subttxrend/common/Logger.hpp>
 #include <subttxrend/common/StringUtils.hpp>
 
+#include <fstream>
+#include <json/json.h>
+
+#define BUILD_CFG_FILE_PATH "/var/sky/build/buildConfig.json"
+
 namespace subttxrend
 {
 namespace app
@@ -155,6 +160,42 @@ const char* Configuration::getValue(const std::string& key) const
     }
 
     return m_configFile.getCstr(key);
+}
+
+std::string Configuration::getRegionInfo() const
+{
+    std::string key = "country";
+    std::string region = "us";
+
+    std::ifstream file(BUILD_CFG_FILE_PATH);
+    if (!file.is_open()) {
+        g_logger.info("%s Unable to open buildconfig.json, returning default value (%s) ", __func__, region.c_str());
+	return region;
+    }
+
+    std::stringstream jsonString;
+    jsonString << file.rdbuf();
+    file.close();
+
+    Json::CharReaderBuilder builder;
+    std::string errors;
+    Json::Value jsonData;
+
+    bool parsingSuccessful = parseFromStream(builder, jsonString, &jsonData, &errors);
+    if (!parsingSuccessful) {
+        g_logger.info("%s Error parsing JSON string:%s, returning default value (%s) ", __func__, errors.c_str(), region.c_str());
+	return region;
+    }
+
+    if (jsonData.isMember(key)){
+        region = jsonData[key].asString();
+	g_logger.info("%s Parsed region info, region:%s ", __func__, region.c_str());
+    }
+    else {
+        g_logger.info("%s Region info not found in buildconfig.json, returning default value (%s) ", __func__, region.c_str()); 
+    }
+
+    return region;
 }
 
 } // namespace app

--- a/subttxrend-app/src/Configuration.hpp
+++ b/subttxrend-app/src/Configuration.hpp
@@ -59,6 +59,8 @@ public:
      */
     std::string getMainContextSocketPath() const;
 
+    std::string getRegionInfo() const;
+
     /**
      * Returns teletext configuration.
      *

--- a/subttxrend-app/src/Controller.cpp
+++ b/subttxrend-app/src/Controller.cpp
@@ -73,10 +73,11 @@ constexpr const std::chrono::milliseconds as_data_acq_timeout{2000};
 
 } /* namespace  */
 
-Controller::Controller(Configuration const& config, gfx::EnginePtr gfxEngine, gfx::WindowPtr gfxWindow)
+Controller::Controller(Configuration const& config, gfx::EnginePtr gfxEngine, gfx::WindowPtr gfxWindow, const std::string region)
     : m_config(config)
     , m_gfxEngine(gfxEngine)
     , m_gfxWindow(gfxWindow)
+    , m_region(region)
     , m_fontCache{std::make_shared<gfx::PrerenderedFontCache>()}
     , m_stcProvider()
     , m_logger("App", "Controller", this)
@@ -378,7 +379,7 @@ void Controller::processTtmlSelection(const protocol::PacketTtmlSelection& packe
         m_logger.oserror(__LOGGER_FUNC__, " exception: ", e.what());
     }
 
-    pushController(std::make_shared<TtmlController>(packet, m_config.getTtmlConfig(), m_gfxWindow, properties));
+    pushController(std::make_shared<TtmlController>(packet, m_config.getTtmlConfig(), m_gfxWindow, properties, m_region));
 }
 
 void Controller::processWebvttSelection(const protocol::PacketWebvttSelection& packet)

--- a/subttxrend-app/src/Controller.hpp
+++ b/subttxrend-app/src/Controller.hpp
@@ -83,7 +83,8 @@ class Controller : private common::NonCopyable,
     Controller(
             Configuration const& config,
             gfx::EnginePtr gfxEngine,
-            gfx::WindowPtr gfxWindow);
+            gfx::WindowPtr gfxWindow,
+            const std::string region);
     // clang-format on
 
     /**
@@ -324,6 +325,8 @@ private:
 
     gfx::EnginePtr m_gfxEngine;
     gfx::WindowPtr m_gfxWindow;
+
+    std::string m_region;
 
     /** Processes timestamp messages and provides stc value. */
     StcProvider m_stcProvider;

--- a/subttxrend-app/src/TtmlController.cpp
+++ b/subttxrend-app/src/TtmlController.cpp
@@ -33,13 +33,14 @@ namespace app {
 TtmlController::TtmlController(const protocol::PacketChannelSpecific& dataPacket,
                                const common::ConfigProvider& config,
                                gfx::WindowPtr const& gfxWindow,
-                               common::Properties const& properties)
+                               common::Properties const& properties,
+                               const std::string region)
     : m_channel()
     , m_logger("App", "TtmlController", this)
     , m_ttmlEngine(ttmlengine::Factory::createTtmlEngine())
 {
     m_logger.ostrace(__LOGGER_FUNC__, " created");
-    m_ttmlEngine->init(&config, gfxWindow.get(), properties);
+    m_ttmlEngine->init(&config, gfxWindow.get(), properties, region);
     select(dataPacket);
 }
 

--- a/subttxrend-app/src/TtmlController.hpp
+++ b/subttxrend-app/src/TtmlController.hpp
@@ -51,7 +51,8 @@ class TtmlController final : public ControllerInterface
     TtmlController(const protocol::PacketChannelSpecific& dataPacket,
                    const common::ConfigProvider& config,
                    gfx::WindowPtr const& gfxWindow,
-                   common::Properties const& properties);
+                   common::Properties const& properties,
+                   const std::string region);
     ~TtmlController();
 
     void process() override;

--- a/subttxrend-ctrl/CMakeLists.txt
+++ b/subttxrend-ctrl/CMakeLists.txt
@@ -155,6 +155,7 @@ target_link_libraries(${LIBRARY_NAME} ${LIBSUBTTXRENDTTML_LIBRARIES})
 target_link_libraries(${LIBRARY_NAME} ${LIBSUBTTXRENDWEBVTT_LIBRARIES})
 target_link_libraries(${LIBRARY_NAME} pthread)
 target_link_libraries(${LIBRARY_NAME} boost_system)
+target_link_libraries(${LIBRARY_NAME} jsoncpp)
 
 #
 # Install rules

--- a/subttxrend-ctrl/src/Configuration.hpp
+++ b/subttxrend-ctrl/src/Configuration.hpp
@@ -59,6 +59,9 @@ public:
      */
     std::string getMainContextSocketPath() const;
 
+
+    std::string getRegionInfo() const;
+
     /**
      * Returns teletext configuration.
      *

--- a/subttxrend-ctrl/src/TtmlController.cpp
+++ b/subttxrend-ctrl/src/TtmlController.cpp
@@ -33,13 +33,14 @@ namespace app {
 TtmlController::TtmlController(const protocol::PacketChannelSpecific& dataPacket,
                                const common::ConfigProvider& config,
                                gfx::WindowPtr const& gfxWindow,
-                               common::Properties const& properties)
+                               common::Properties const& properties,
+                               const std::string region)
     : m_channel()
     , m_logger("App", "TtmlController", this)
     , m_ttmlEngine(ttmlengine::Factory::createTtmlEngine())
 {
     m_logger.ostrace(__LOGGER_FUNC__, " created");
-    m_ttmlEngine->init(&config, gfxWindow.get(), properties);
+    m_ttmlEngine->init(&config, gfxWindow.get(), properties, region);
     select(dataPacket);
 }
 

--- a/subttxrend-ctrl/src/TtmlController.hpp
+++ b/subttxrend-ctrl/src/TtmlController.hpp
@@ -51,7 +51,8 @@ class TtmlController final : public ControllerInterface
     TtmlController(const protocol::PacketChannelSpecific& dataPacket,
                    const common::ConfigProvider& config,
                    gfx::WindowPtr const& gfxWindow,
-                   common::Properties const& properties);
+                   common::Properties const& properties,
+                   const std::string region);
     ~TtmlController();
 
     void process() override;

--- a/subttxrend-ttml/include/TtmlEngine.hpp
+++ b/subttxrend-ttml/include/TtmlEngine.hpp
@@ -58,7 +58,7 @@ public:
      */
     virtual void init(const common::ConfigProvider* configProvider,
                       gfx::Window* gfxWindow,
-                      common::Properties const& properties) = 0;
+                      common::Properties const& properties, const std::string region) = 0;
 
     /**
      * Notifies size of related video content. Used for position and size calculations.

--- a/subttxrend-ttml/src/Parser/DocumentInstance.hpp
+++ b/subttxrend-ttml/src/Parser/DocumentInstance.hpp
@@ -74,6 +74,11 @@ public:
         m_currentImageElement = std::shared_ptr<ImageElement>();
     }
 
+    void setRegionInfo(const std::string region)
+    {
+	    m_regionInfo = region;
+    }
+
     /**
      * Adds element to the document.
      *
@@ -308,6 +313,7 @@ public:
 
                                     auto styleId = content->getStyleId();
                                     textChunk.m_style.setStyleId(styleId);
+                                    textChunk.m_style.setRegionInfo(m_regionInfo);
                                     textChunk.m_style.merge(content->getStyleAttributes());
 
                                     m_logger.ostrace(__LOGGER_FUNC__, " chunk: \'", textChunk.m_text, "\'", ", style: ", textChunk.m_style.toStr());
@@ -591,6 +597,8 @@ private:
 
     /** List of found content nodes. */
     std::vector<std::shared_ptr<BodyElement> > m_content;
+
+    std::string m_regionInfo;
 
     /** Logger object. */
     mutable subttxrend::common::Logger m_logger;

--- a/subttxrend-ttml/src/Parser/Parser.hpp
+++ b/subttxrend-ttml/src/Parser/Parser.hpp
@@ -44,10 +44,11 @@ public:
     /**
      * Constructor.
      */
-    Parser() :
+    Parser(const std::string region) :
             m_saxParser(*this), m_logger("TtmlEngine", "Parser")
     {
-        // noop
+
+        m_docInstance.setRegionInfo(region);
     }
 
     /**

--- a/subttxrend-ttml/src/Parser/StyleSet.cpp
+++ b/subttxrend-ttml/src/Parser/StyleSet.cpp
@@ -27,6 +27,7 @@
 #include <string>
 #include <utility>
 #include <sstream>
+#include <subttxrend/common/Logger.hpp>
 
 namespace subttxrend
 {
@@ -189,6 +190,9 @@ StyleSet::DisplayAlign parseDisplayAlign(const std::string& text)
     return displayAlign;
 }
 
+common::Logger logger("TtmlEngine", "StyleSet");
+
+
 } // namespace anonymous
 
 const ColorArgb& StyleSet::getColor() const
@@ -240,6 +244,10 @@ void StyleSet::setStyleId(const std::string& styleId)
 {
     m_styleId = styleId;
 }
+void StyleSet::setRegionInfo(const std::string region)
+{
+    m_region = region;
+}
 void StyleSet::merge(const Attributes& attributes)
 {
     for (const auto& attr : attributes) {
@@ -279,7 +287,10 @@ void StyleSet::parseAttribute(const std::string& name,
             m_fontSize = sizeResult.size;
         }
     } else if (name == "textAlign") {
-        m_textAlign = parseTextAlign(value);
+        if(m_region == "it")
+            logger.info("%s LLAMA-8155: Ignoring incoming textAlign property (%s) - defaulting to \"center\"", __LOGGER_FUNC__, value.c_str());
+        else
+            m_textAlign = parseTextAlign(value);
     } else if (name == "displayAlign") {
         m_displayAlign = parseDisplayAlign(value);
     } else if (name == "fontFamily") {

--- a/subttxrend-ttml/src/Parser/StyleSet.hpp
+++ b/subttxrend-ttml/src/Parser/StyleSet.hpp
@@ -63,6 +63,7 @@ public:
 
     void setStyleId(const std::string& styleId);
     void merge(const Attributes& attributes);
+    void setRegionInfo(const std::string region);
 
     std::string toStr();
 
@@ -82,6 +83,7 @@ private:
     DomainValue m_lineHeight{DomainValue::Type::PERCENTAGE_HUNDREDTHS, 100*100};
     Outline m_textOutline;
     std::string m_styleId;
+    std::string m_region;
 };
 
 std::ostream& operator<<(std::ostream& out, const StyleSet::TextAlign textAlign);

--- a/subttxrend-ttml/src/TtmlEngineImpl.cpp
+++ b/subttxrend-ttml/src/TtmlEngineImpl.cpp
@@ -68,7 +68,8 @@ void TtmlEngineImpl::clear()
 
 void TtmlEngineImpl::init(const common::ConfigProvider* configProvider,
                           gfx::Window* gfxWindow,
-                          common::Properties const& properties)
+                          common::Properties const& properties,
+                          const std::string region)
 {
     m_logger.osinfo(__LOGGER_FUNC__);
 
@@ -82,7 +83,7 @@ void TtmlEngineImpl::init(const common::ConfigProvider* configProvider,
         createTimingDoc();
     }
 
-    m_parser = std::make_unique<Parser>();
+    m_parser = std::make_unique<Parser>(region);
     m_renderer = std::make_unique<TtmlRenderer>(configProvider, gfxWindow, m_dataDumper);
 
     m_docTransformer.setProperties(properties);

--- a/subttxrend-ttml/src/TtmlEngineImpl.hpp
+++ b/subttxrend-ttml/src/TtmlEngineImpl.hpp
@@ -59,7 +59,7 @@ public:
     /** @copydoc TtmlEngine::init */
     virtual void init(const common::ConfigProvider* configProvider,
                       gfx::Window*  gfxEngine,
-                      common::Properties const& properties) override;
+                      common::Properties const& properties, const std::string region) override;
 
     /** @copydoc TtmlEngine::setRelatedVideoSize */
     virtual void setRelatedVideoSize(gfx::Size relatedVideoSize) override;


### PR DESCRIPTION
Reason for change: Parse region info from config and apply patch at runtime. Test Procedure: Check for CC appearance.
Risks: Low
Signed-off-by:Anaswara KookkalAnaswara_Kookkal@comcast.com