### PR TITLE
RDKEMW-2465:720p graphics for Subttxrend instead of 1080p

### DIFF
--- a/subttxrend-cc/include/CcWindow.hpp
+++ b/subttxrend-cc/include/CcWindow.hpp
@@ -28,6 +28,8 @@
 #include "CcGfx.hpp"
 #include "CcTextDrawer.hpp"
 
+#define SCALING_FACTOR 0.67
+
 namespace subttxrend
 {
 namespace cc

--- a/subttxrend-cc/src/CcRenderer.cpp
+++ b/subttxrend-cc/src/CcRenderer.cpp
@@ -134,7 +134,7 @@ void Renderer::clear()
 
 void Renderer::show()
 {
-    m_window->setSize(gfx::Size{1920, 1080});
+    m_window->setSize(gfx::Size{1280, 720});
     m_window->setVisible(true);
 }
 

--- a/subttxrend-cc/src/CcTextGfxDrawer.cpp
+++ b/subttxrend-cc/src/CcTextGfxDrawer.cpp
@@ -208,7 +208,7 @@ void TextGfxDrawer::setPenAttributes(PenAttributes penattrs)
         break;
     }
 
-    m_font = m_fontCache->getFont(fontName, size, true, penattrs.italics);
+    m_font = m_fontCache->getFont(fontName, size * SCALING_FACTOR, true, penattrs.italics);
     m_attrs = penattrs;
 }
 

--- a/subttxrend-cc/src/CcWindow.cpp
+++ b/subttxrend-cc/src/CcWindow.cpp
@@ -414,6 +414,10 @@ Point Window::calculateAnchorTopLeftPoint(const Dimensions& bDim)
             anchorCoords.y = anchorCoords.y - bDim.h;
             break;
     }
+
+    anchorCoords.x *= SCALING_FACTOR;
+    anchorCoords.y *= SCALING_FACTOR;
+
     return anchorCoords;
 }
 
@@ -535,8 +539,11 @@ Dimensions Window::calculateRects4Text(std::vector<Rect>& tdRects)
         biggestDimensions.h = std::max(biggestDimensions.h, dimWithMargin.h+textRelativeY);
     }
 
+    biggestDimensions.w *= 1.5;
+
     biggestDimensions.h = std::max(biggestDimensions.h, maxFontHeight * m_def.row_count);
     biggestDimensions.w = std::max(biggestDimensions.w, maxAdvance * m_def.col_count);
+
     return biggestDimensions;
 }
 
@@ -588,6 +595,9 @@ void Window::draw()
 
     const auto anchorPoint = calculateAnchorTopLeftPoint(windowDimensions);
 
+    windowDimensions.w *= SCALING_FACTOR;
+    windowDimensions.h *= SCALING_FACTOR;
+
     logger.debug("%s window dimensions (%d %d) anchor point (%d %d)",
         __LOGGER_FUNC__,
         windowDimensions.w,
@@ -604,7 +614,7 @@ void Window::draw()
 Point Window::calculate(const ScreenInfo& screenInfo)
 {
     Point ret;
-    const auto screenSafeHeight = [&]{
+    /*const auto screenSafeHeight = [&]{
     if(m_608Enabled && m_textDrawers.size()>0 && m_textDrawers.back())
     {
         auto fH = m_textDrawers.back()->fontHeight();
@@ -617,19 +627,19 @@ Point Window::calculate(const ScreenInfo& screenInfo)
         return std::min(screenInfo.height, fH * screenInfo.heightSegments);
      } else
         return screenInfo.safeHeight;
-    }();
+    }();*/
 
     ret.x = (screenInfo.width - screenInfo.safeWidth)/2;
-    ret.y = (screenInfo.height - screenSafeHeight)/2;
+    ret.y = (screenInfo.height - screenInfo.safeHeight)/2;
     if (m_def.relative_pos)
     {
         ret.x += ((screenInfo.safeWidth * m_def.anchor_horizontal) / 100);
-        ret.y += ((screenSafeHeight * m_def.anchor_vertical) / 100);
+        ret.y += ((screenInfo.safeHeight * m_def.anchor_vertical) / 100);
     }
     else
     {
         ret.x += screenInfo.safeWidth/screenInfo.widthSegments * m_def.anchor_horizontal;
-        ret.y += screenSafeHeight/screenInfo.heightSegments * m_def.anchor_vertical;
+        ret.y += screenInfo.safeHeight/screenInfo.heightSegments * m_def.anchor_vertical;
     }
     return ret;
 }

--- a/subttxrend-gfx/src/WindowImpl.cpp
+++ b/subttxrend-gfx/src/WindowImpl.cpp
@@ -42,7 +42,7 @@ namespace
 
 common::Logger g_logger("Gfx", "WindowImpl");
 
-const gfx::Size DEFAULT_WINDOW_SIZE{1920, 1080};
+const gfx::Size DEFAULT_WINDOW_SIZE{1280, 720};
 
 class NullEngineHooks : public EngineHooks
 {

--- a/subttxrend-ttml/src/TtmlRenderer.cpp
+++ b/subttxrend-ttml/src/TtmlRenderer.cpp
@@ -32,7 +32,7 @@ namespace ttmlengine
 
 namespace {
 
-const gfx::Size MAX_SURFACE_SIZE{1920, 1080};
+const gfx::Size MAX_SURFACE_SIZE{1280, 720};
 // 1x1 is special case for UI
 const gfx::Size MIN_SURFACE_SIZE{2, 2};
 

--- a/subttxrend-ttml/src/TtmlRenderer.hpp
+++ b/subttxrend-ttml/src/TtmlRenderer.hpp
@@ -111,7 +111,7 @@ private:
     /** Window pointer. */
     gfx::Window* const m_gfxWindow;
 
-    const gfx::Size DEFAULT_SURFACE_SIZE{1920, 1080};
+    const gfx::Size DEFAULT_SURFACE_SIZE{1280, 720};
     gfx::Size m_surfaceSize{DEFAULT_SURFACE_SIZE};
 
     /** Value converter. */

--- a/subttxrend-webvtt/src/include/LineBuilder.hpp
+++ b/subttxrend-webvtt/src/include/LineBuilder.hpp
@@ -133,7 +133,7 @@ private:
     std::string     getFontFamily(WebVTTConfig config);
     void            getUserDefinedColorAttributes(Style &style);
 
-    Converter       m_converter {1920, 1080};
+    Converter       m_converter {1280, 720};
     FontCachePtr    m_fontCache {std::make_unique<gfx::PrerenderedFontCache>()};
     
     std::string     m_fontFamily {"Cinecav Sans"};

--- a/subttxrend-webvtt/src/include/WebVTTConverter.hpp
+++ b/subttxrend-webvtt/src/include/WebVTTConverter.hpp
@@ -130,8 +130,8 @@ private:
     inline int vhToPixels(T vh) const { return (int)(((float)m_displayHeight / 100.0f) * vh); }
 
     inline float hundredthsToV(float hundredths) const { return hundredths / 100.0f; }
-    int m_displayWidth {1920};
-    int m_displayHeight {1080};
+    int m_displayWidth {1280};
+    int m_displayHeight {720};
 
     int        m_defaultLineHeight {constants::kDefaultLineHeight};  //vh
     int        m_defaultFontHeight {constants::kDefaultFontHeight};  //vh

--- a/subttxrend-webvtt/src/include/WebVTTRenderer.hpp
+++ b/subttxrend-webvtt/src/include/WebVTTRenderer.hpp
@@ -101,7 +101,7 @@ private:
 
     WinPtr              m_gfxPtr;
 
-    const gfx::Size     DEFAULT_SURFACE_SIZE{1920, 1080};
+    const gfx::Size     DEFAULT_SURFACE_SIZE{1280, 720};
     gfx::Size           m_surfaceSize{DEFAULT_SURFACE_SIZE};
     WebVTTConfig        m_config;
 

--- a/subttxrend-webvtt/src/include/WebvttEngineImpl.hpp
+++ b/subttxrend-webvtt/src/include/WebvttEngineImpl.hpp
@@ -133,7 +133,7 @@ private:
     CueList                                 m_timeline;
     std::list<CueSharedPtr>                 m_shownDocuments;
     RegionMap                               m_cachedRegionMap;
-    const gfx::Size                         DEFAULT_SURFACE_SIZE{1920, 1080};
+    const gfx::Size                         DEFAULT_SURFACE_SIZE{1280, 720};
     gfx::Size                               m_surfaceSize{DEFAULT_SURFACE_SIZE};
 
 };


### PR DESCRIPTION
Reason for change: change subttxrend graphics to 720p instead of 1080p
Test Procedure: validate cc/ttml/webvtt, sarnoff test cases
Risks: Low
Signed-off-by: Anaswara KookkalAnaswara_Kookkal@comcast.com