### PR TITLE
RDKEMW-9594 : subttxrend-crash due to signal 6

### DIFF
--- a/subttxrend-webvtt/src/WebvttEngineImpl.cpp
+++ b/subttxrend-webvtt/src/WebvttEngineImpl.cpp
@@ -242,6 +242,8 @@ void WebvttEngineImpl::addData(const std::uint8_t* buffer,
             m_cachedRegionMap = GetUnifiedRegionMap(m_timeline, regionMap, m_cachedRegionMap);
         } catch (const WebVTTException& e) {
             g_logger.oswarning(__LOGGER_FUNC__, e.what());
+        } catch (const std::exception& e) {
+            g_logger.osinfo(__LOGGER_FUNC__, e.what());
         }
         
         if (preParseTimeLineSize == m_timeline.size())


### PR DESCRIPTION
Reason for change: catch std exception while creating string
Test Procedure: Monitor subttxrend-app crash
Risks: Low
Signed-off-by: Anaswara KookkalAnaswara_Kookkal@comcast.com