### PR TITLE
SERXIONE-8286: subttxrend-app crash with SDK22

### DIFF
--- a/subttxrend-gfx/src/WaylandBackendEgl.cpp
+++ b/subttxrend-gfx/src/WaylandBackendEgl.cpp
@@ -141,9 +141,9 @@ bool WaylandBackendEgl::initRendering()
 
 #ifdef USE_UPSTREAM_WAYLAND
 #ifdef EGL_PLATFORM_WAYLAND_EXT
-    PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT= (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+    PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT = reinterpret_cast<PFNEGLGETPLATFORMDISPLAYEXTPROC>(eglGetProcAddress("eglGetPlatformDisplayEXT"));
     if (eglGetPlatformDisplayEXT)
-      m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT, getDisplay()->getNativeObject(), NULL);
+        m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT, getDisplay()->getNativeObject(), nullptr);
     else
 #endif
 #endif

--- a/subttxrend-gfx/src/WaylandBackendEgl.cpp
+++ b/subttxrend-gfx/src/WaylandBackendEgl.cpp
@@ -24,6 +24,9 @@
 
 #include "Pixel.hpp"
 #include "Pixmap.hpp"
+#ifdef USE_UPSTREAM_WAYLAND
+#include <EGL/eglext.h>
+#endif
 
 namespace subttxrend
 {
@@ -136,7 +139,19 @@ bool WaylandBackendEgl::initRendering()
 
     g_logger.trace("%s", __func__);
 
-    m_eglDisplay = eglGetDisplay(getDisplay()->getNativeObject());
+#ifdef USE_UPSTREAM_WAYLAND
+#ifdef EGL_PLATFORM_WAYLAND_EXT
+    PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT= (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+    if (eglGetPlatformDisplayEXT)
+      m_eglDisplay = eglGetPlatformDisplayEXT(EGL_PLATFORM_WAYLAND_EXT, getDisplay()->getNativeObject(), NULL);
+    else
+#endif
+#endif
+    if (!m_eglDisplay)
+    {
+        m_eglDisplay = eglGetDisplay(getDisplay()->getNativeObject());
+    }
+
     if (!m_eglDisplay)
     {
         g_logger.error("%s - cannot get EGL display (%d)", __func__,


### PR DESCRIPTION
Reason for change: To address the subtec crash seen in Bcom streambox with RDKE
Test Procedure: check for any subtec crash when playing app, subtec sanity tests
Priority: P1
Risks: Low