### PR TITLE
RDKEMW-18622 : Fix coverity warnings in subttxrend-cc

### DIFF
--- a/subttxrend-cc/include/CcTextDrawer.hpp
+++ b/subttxrend-cc/include/CcTextDrawer.hpp
@@ -24,6 +24,7 @@
 #include <vector>
 #include <memory>
 #include <string>
+#include <utility>
 #include "CcCommand.hpp"
 #include "CcGfx.hpp"
 

--- a/subttxrend-cc/include/CcTextDrawer.hpp
+++ b/subttxrend-cc/include/CcTextDrawer.hpp
@@ -42,7 +42,7 @@ class TextDrawer
 {
 public:
     TextDrawer(std::shared_ptr<Gfx> gfx, std::shared_ptr<gfx::PrerenderedFontCache> fontCache, FontGroup fonts,  int row = 0, int column = 0):
-        column(column), row(row), m_gfx(gfx), m_fontCache{fontCache}, m_fonts(fonts), midrow(false), padding(0)
+        column(column), row(row), m_gfx(std::move(gfx)), m_fontCache{std::move(fontCache)}, m_fonts(fonts), midrow(false), padding(0)
     {}
     virtual ~TextDrawer() = default;
 

--- a/subttxrend-cc/src/CcCommandParser.cpp
+++ b/subttxrend-cc/src/CcCommandParser.cpp
@@ -127,7 +127,16 @@ void CommandParser::processBlock(const ServiceBlock &block)
                     m_serviceBlock[itr+m_serviceBlockSize] = data[itr];
                 }
                 m_serviceBlockSize += data_len;
-                consumed = (this->*fun)(&m_serviceBlock[0], m_serviceBlockSize);
+                if (fun)
+                {
+                    consumed = (this->*fun)(&m_serviceBlock[0], m_serviceBlockSize);
+                }
+                else
+                {
+                    m_cmdLengthExceeds = false;
+                    m_serviceBlockSize = 0;
+                    consumed = data_len;
+                }
             }
             else
             {
@@ -590,7 +599,7 @@ size_t CommandParser::handleG1(const uint8_t *data, size_t)
         str.push_back(0x80 | (ch & 0x3f));
     }
 
-    m_proc->report(str);
+    m_proc->report(std::move(str));
 
     return 1;
 }

--- a/subttxrend-cc/src/CcController.cpp
+++ b/subttxrend-cc/src/CcController.cpp
@@ -58,7 +58,7 @@ bool Controller::init(gfx::Window* gfxWindow, std::shared_ptr<gfx::PrerenderedFo
     logger.info("%s", __func__);
 
     renderer.reset(new Renderer(gfxWindow));
-    m_fontCache = fontCache;
+    m_fontCache = std::move(fontCache);
     winCtrl = std::make_unique<WindowController>(renderer, m_fontCache);
     parser.setProcessor(winCtrl.get());
 
@@ -325,7 +325,7 @@ void Controller::processCcpQueue()
     for(auto& ccp : cc708Ccp)
     {
         offset = 0;
-        auto ccpData = ccp->getCcpData();
+        const auto& ccpData = ccp->getCcpData();
         while (offset < ccpData.size())
         {
             std::unique_ptr<ServiceBlock> sb(new ServiceBlock(ccpData, offset));

--- a/subttxrend-cc/src/CcTextGfxDrawer.cpp
+++ b/subttxrend-cc/src/CcTextGfxDrawer.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<TextDrawer> TextDrawer::create(std::shared_ptr<Gfx> gfx, std::sh
 }
 
 TextGfxDrawer::TextGfxDrawer(std::shared_ptr<Gfx> gfx, std::shared_ptr<gfx::PrerenderedFontCache> fontCache, FontGroup fonts, int row, int column):
-    TextDrawer(gfx, fontCache, fonts, row, column),
+    TextDrawer(std::move(gfx), std::move(fontCache), fonts, row, column),
     m_flashState(FlashControl::Show),
     logger("ClosedCaptions", "TextGfxDrawer"),
     m_overridePenAttributes(false)

--- a/subttxrend-cc/src/CcWindow.cpp
+++ b/subttxrend-cc/src/CcWindow.cpp
@@ -45,7 +45,7 @@ static const int HorizontalMargin = 5;
 #define MAX_ROW_COUNT 12
 
 Window::Window(std::shared_ptr<Gfx> gfx, std::shared_ptr<gfx::PrerenderedFontCache> font, WindowDefinition def, bool enable608):
-    m_gfx(gfx), m_fontCache{font}, m_def(def), m_608Enabled(enable608),
+    m_gfx(std::move(gfx)), m_fontCache{std::move(font)}, m_def(def), m_608Enabled(enable608),
     m_fonts(enable608 ? screenInfo608.fonts : screenInfo708.fonts),
     m_changed(false), m_visibilityChanged(false), logger("ClosedCaptions", "Window")
 {
@@ -96,7 +96,7 @@ void Window::report(std::string str)
     {
         m_changed = true;
         ensureTextDrawer();
-        m_textDrawers.back()->report(str, m_def);
+        m_textDrawers.back()->report(std::move(str), m_def);
     }
 }
 

--- a/subttxrend-cc/src/CcWindowController.cpp
+++ b/subttxrend-cc/src/CcWindowController.cpp
@@ -28,8 +28,8 @@ namespace cc
 {
 
 WindowController::WindowController(std::shared_ptr<Gfx> gfx, std::shared_ptr<gfx::PrerenderedFontCache> fontCache)
-        : m_gfx(gfx),
-          m_fontCache(fontCache),
+        : m_gfx(std::move(gfx)),
+          m_fontCache(std::move(fontCache)),
           m_selectedWindow(nullptr),
           m_flashTransition(std::chrono::steady_clock::now()),
           m_windowTransition(std::chrono::steady_clock::now()),
@@ -243,7 +243,7 @@ void WindowController::report(std::string str)
 {
     logger.trace("ses ");
     if (m_selectedWindow)
-        m_selectedWindow->report(str);
+        m_selectedWindow->report(std::move(str));
 }
 
 void WindowController::hideWindows(WindowsMap wm)
@@ -372,7 +372,7 @@ void WindowController::setTabOffset(uint8_t offset)
 
 Window* WindowController::createWindow(std::shared_ptr<Gfx> gfx, WindowDefinition windef)
 {
-    return new Window(gfx, m_fontCache, windef, m_608Enabled);
+    return new Window(std::move(gfx), m_fontCache, windef, m_608Enabled);
 }
 
 void WindowController::executeOnWindows(const WindowsMap& wm, std::function<void (Window*)> method)


### PR DESCRIPTION
Reason for change: Fix coverity warnings in subttxrend-cc Test Procedure: Regression test in CC
Risks: medium
Signed-off-by:Anaswara Kookkal Anaswara_Kookkal@comcast.com