### PR TITLE
RDKEMW-19878 : Fix coverity warnings in subttxrend-ctrl

### DIFF
--- a/subttxrend-ctrl/src/CcSubController.cpp
+++ b/subttxrend-ctrl/src/CcSubController.cpp
@@ -23,6 +23,7 @@
 #include <subttxrend/protocol/PacketData.hpp>
 
 #include <cassert>
+#include <utility>
 
 namespace subttxrend {
 namespace ctrl {

--- a/subttxrend-ctrl/src/CcSubController.cpp
+++ b/subttxrend-ctrl/src/CcSubController.cpp
@@ -56,7 +56,7 @@ void CcSubController::select(protocol::PacketChannelSpecific const& packet)
 CcSubController::CcSubController(protocol::PacketChannelSpecific const& packet, gfx::WindowPtr const& gfxWindow, std::shared_ptr<gfx::PrerenderedFontCache> fontCache)
     : m_controller()
     , m_logger("App", "CcSubController")
-    , m_fontCache{fontCache}
+    , m_fontCache{std::move(fontCache)}
 {
     m_logger.oswarning(__LOGGER_FUNC__, " created");
     if (!m_controller.init(gfxWindow.get(), m_fontCache)) {

--- a/subttxrend-ctrl/src/Options.hpp
+++ b/subttxrend-ctrl/src/Options.hpp
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <utility>
 
 namespace subttxrend
 {

--- a/subttxrend-ctrl/src/Options.hpp
+++ b/subttxrend-ctrl/src/Options.hpp
@@ -155,11 +155,11 @@ private:
               Mode mode,
               std::string defaultValue = std::string()) :
                 m_key(key),
-                m_longName(longName),
-                m_shortName(shortName),
-                m_description(description),
+                m_longName(std::move(longName)),
+                m_shortName(std::move(shortName)),
+                m_description(std::move(description)),
                 m_mode(mode),
-                m_defaultValue(defaultValue)
+                m_defaultValue(std::move(defaultValue))
         {
             // noop
         }


### PR DESCRIPTION
Reason for change: Fix coverity warnings in subttxrend-ctrl Test Procedure: Regression test in CC
Risks: medium
Signed-off-by:Anaswara Kookkal Anaswara_Kookkal@comcast.com