### PR TITLE
RDKEMW-19940 : Fix coverity warnings in subttxrend-app

### DIFF
--- a/subttxrend-app/src/Controller.cpp
+++ b/subttxrend-app/src/Controller.cpp
@@ -74,8 +74,8 @@ constexpr const std::chrono::milliseconds connection_status_check_timeout{1000};
 
 Controller::Controller(ctrl::Configuration const& config, gfx::EnginePtr gfxEngine, gfx::WindowPtr gfxWindow)
     : m_config(config)
-    , m_gfxEngine(gfxEngine)
-    , m_gfxWindow(gfxWindow)
+    , m_gfxEngine(std::move(gfxEngine))
+    , m_gfxWindow(std::move(gfxWindow))
     , m_fontCache{std::make_shared<gfx::PrerenderedFontCache>()}
     , m_stcProvider()
     , m_logger("App", "Controller", this)

--- a/subttxrend-app/x86_builder/src/rdklogger/src/logger.cpp
+++ b/subttxrend-app/x86_builder/src/rdklogger/src/logger.cpp
@@ -84,13 +84,12 @@ void RDK_LOG(rdk_LogLevel level,
              const char *format,
              ...)
 {
-    char buffer[32 * 1024];
+    thread_local char buffer[32 * 1024];
 
     std::va_list arguments;
 
     va_start(arguments, format);
-    vsnprintf(buffer, sizeof(buffer) - 1, format, arguments);
-    buffer[sizeof(buffer) - 1] = 0;
+    vsnprintf(buffer, sizeof(buffer), format, arguments);
     va_end(arguments);
 
     printf("%s\n", buffer);

--- a/subttxrend-app/x86_builder/src/rdklogger/src/logger.cpp
+++ b/subttxrend-app/x86_builder/src/rdklogger/src/logger.cpp
@@ -89,8 +89,13 @@ void RDK_LOG(rdk_LogLevel level,
     std::va_list arguments;
 
     va_start(arguments, format);
-    vsnprintf(buffer, sizeof(buffer), format, arguments);
+    int ret = vsnprintf(buffer, sizeof(buffer), format, arguments);
     va_end(arguments);
+
+    if (ret < 0)
+    {
+        return;
+    }
 
     printf("%s\n", buffer);
 }


### PR DESCRIPTION
Reason for change: Fix coverity warnings in subttxrend-app Test Procedure: Regression test in CC
Risks: medium
Signed-off-by:Anaswara Kookkal Anaswara_Kookkal@comcast.com